### PR TITLE
Display SVG icons in buttons

### DIFF
--- a/_sass/derangedsenators/buttons.scss
+++ b/_sass/derangedsenators/buttons.scss
@@ -64,7 +64,7 @@
     margin-top: -1em;
     margin-bottom: -0.8em;
     vertical-align: middle;
-    fill: $brand-primary;
+    fill: $brand-inverse;
     height: 1.3125rem;
     width: auto;
     padding: .1rem;


### PR DESCRIPTION
At the moment, their fill colour is the same as the button colour and therefore they cannot be seen