### PR TITLE
DlInf: For Windows and Mac, provide standalone builds

### DIFF
--- a/assets/json/dlinf.json
+++ b/assets/json/dlinf.json
@@ -1,6 +1,6 @@
 {
-  "windows": "launcher",
-  "mac": "launcher",
+  "windows": "standalone",
+  "mac": "standalone",
   "linux": "pkgman",
   "android": "standalone",
   "ios": "unsupported",


### PR DESCRIPTION
The Launcher is not ready which means that on Desktops, the website does not serve anything.