### PR TITLE
Add a maintenance checker for homepage

### DIFF
--- a/assets/js/maintenance-check.js
+++ b/assets/js/maintenance-check.js
@@ -1,0 +1,22 @@
+
+
+window.onload = function (){
+    var xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "https://derangedsenators.github.io/static_api/server/maintenance.json", true);
+    xmlhttp.send();
+    xmlhttp.onreadystatechange = function() {
+        if (this.readyState === 4 && this.status === 200) {
+            console.log(xmlhttp.responseText)
+            var myArr = JSON.parse(xmlhttp.responseText);
+            if(myArr.scheduled === true){
+                var element = document.getElementById("maintenance-info");
+                var msg = "The Server may be down for routine updates/maintenance from " + myArr.information.start_from + "UTC On " +   myArr.information.start_date + "to " + + myArr.information.end_at + "UTC On " +   myArr.information.end_date + ". You may not be able to connect to the server to play during this period"
+                element.innerText = myArr.message
+
+            } else{
+                var element = document.getElementById("maintenance-div");
+                element.parentNode.removeChild(element);
+            }
+        }
+    }
+}

--- a/index.html
+++ b/index.html
@@ -18,7 +18,16 @@ scrolljs: true
         </div>
     </div>
 </section>
-
+<div id="maintenance-div">
+    <section class="blog container">
+            <div class="post">
+                <div>
+                    <h2>Server Maintenance Information</h2>
+                    <p id="maintenance-info">Nothing</p>
+                </div>
+            </div>
+    </section>
+</div>
 <section class="game-desc" >
     <div class="container">
         <p>
@@ -62,3 +71,5 @@ scrolljs: true
     </div>
 </section>
 </body>
+
+<script src="{{site.baseurl}}/assets/js/maintenance-check.js"></script>


### PR DESCRIPTION
Just in case the server goes down or we have to work on it over the next few months, we can have some text appear here to let anyone know that they may not be able to play at a given time

It will auto-connect to our static API and add the following layout/text
![image](https://user-images.githubusercontent.com/25727183/113490064-c9c92880-94bf-11eb-921b-56b0db16f2db.png)
